### PR TITLE
> moving sinon to devDependencies to fix an npm-shrinkwrap issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "istanbul": "~0.1.44",
     "async": "~0.2.9",
     "should": "2",
-    "jshint": "~2.3.0"
+    "jshint": "~2.3.0",
+    "sinon": "~1.8.1"
   },
   "dependencies": {
-    "moment": "~2.5.1",
-    "sinon": "~1.8.1"
+    "moment": "~2.5.1"
   }
 }


### PR DESCRIPTION
Encountered an issue on another project where npm wasn't allowing me to shrinkwrap because of mismatching sinon versions. This was happening because sinon wasn't in devDependencies in this package.
